### PR TITLE
Migrate from Tmds.MDns to novotnyllc.Zeroconf

### DIFF
--- a/WLED/WLED.Android/MainActivity.cs
+++ b/WLED/WLED.Android/MainActivity.cs
@@ -1,17 +1,24 @@
 ﻿using System;
 
 using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
 
+using Android.Net.Wifi;
+using Xamarin.Forms.Platform.Android;
+
 namespace WLED.Droid
 {
     [Activity(Label = "WLED", Icon = "@drawable/LogoACh", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation, ScreenOrientation = ScreenOrientation.Portrait)]
     public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
     {
+        WifiManager wifi;
+        WifiManager.MulticastLock multicastLock;
+
         protected override void OnCreate(Bundle savedInstanceState)
         {
             TabLayoutResource = Resource.Layout.Tabbar;
@@ -20,8 +27,24 @@ namespace WLED.Droid
             base.OnCreate(savedInstanceState);
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
+
+            wifi = (WifiManager)ApplicationContext.GetSystemService(Context.WifiService);
+            multicastLock = wifi.CreateMulticastLock("WLED Zeroconf Lock");
+            multicastLock.Acquire();
+
             LoadApplication(new App());
             
+        }
+
+        protected override void OnDestroy()
+        {
+            if (multicastLock != null) 
+            {
+                multicastLock.Release();
+                multicastLock = null;
+            }
+            base.OnDestroy();
+        
         }
 
         public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Android.Content.PM.Permission[] grantResults)

--- a/WLED/WLED.Android/Properties/AndroidManifest.xml
+++ b/WLED/WLED.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="2.0" package="com.nicolagigante.WLED" android:installLocation="auto" android:versionCode="8">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="2.0-Zeroconf" package="com.nicolagigante.WLED" android:installLocation="auto" android:versionCode="9">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/WLED/WLED.Android/Properties/AndroidManifest.xml
+++ b/WLED/WLED.Android/Properties/AndroidManifest.xml
@@ -6,5 +6,6 @@
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.CAMERA" />
+	<uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 	<application android:label="WLED" android:usesCleartextTraffic="true" android:icon="@drawable/logoach"></application>
 </manifest>

--- a/WLED/WLED.Android/WLED.Android.csproj
+++ b/WLED/WLED.Android/WLED.Android.csproj
@@ -39,6 +39,7 @@
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <MandroidI18n />
     <AndroidKeyStore>false</AndroidKeyStore>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/WLED/WLED.Android/WLED.Android.csproj
+++ b/WLED/WLED.Android/WLED.Android.csproj
@@ -39,7 +39,7 @@
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <MandroidI18n />
     <AndroidKeyStore>false</AndroidKeyStore>
-    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/WLED/WLED.iOS/Info.plist
+++ b/WLED/WLED.iOS/Info.plist
@@ -52,5 +52,11 @@
 	<string>Assets.xcassets/AppIcons.appiconset</string>
   <key>CFBundleIconName</key>
   <string>AppIcons</string>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Looking for local mDNS/Bonjour services</string>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_http._tcp.local.</string>
+  </array>
 </dict>
 </plist>

--- a/WLED/WLED/Utilities/DeviceDiscovery.cs
+++ b/WLED/WLED/Utilities/DeviceDiscovery.cs
@@ -12,7 +12,7 @@ namespace WLED
         private static DeviceDiscovery Instance;
         public event EventHandler<DeviceCreatedEventArgs> ValidDeviceFound;
 
-        public async void StartDiscovery()
+        public async Task<bool> StartDiscovery()
         {
             IReadOnlyList<IZeroconfHost> responses = null;
             IReadOnlyList<string> domains;
@@ -38,6 +38,7 @@ namespace WLED
                     OnValidDeviceFound(new DeviceCreatedEventArgs(toAdd, true));
                 }
             }
+            return true;
         }
 
 

--- a/WLED/WLED/Views/DeviceAddPage.xaml
+++ b/WLED/WLED/Views/DeviceAddPage.xaml
@@ -51,12 +51,20 @@
             <Label Text="{x:Static resources:AppResources.FindLights}" 
                    Style="{StaticResource MediumLabelStyle}"
                    Margin="10" />
-
-            <Button Text="{x:Static resources:AppResources.DiscoverLights}" Style="{StaticResource ButtonStyle}" Clicked="OnDiscoveryButtonClicked"/>
-            <Label x:Name="discoveryResultLabel" Text="" 
+            <ActivityIndicator IsVisible="False"
+                           IsRunning="True"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           Margin="20,40,20,20"
+                           x:Name="activityIndicator" />
+            <Label x:Name="discoveryResultLabel" Text="Test" 
                    Style="{StaticResource SmallLabelStyle}" 
+                   HorizontalOptions="Center"
+                   VerticalOptions="Center"
                    Margin="10"
                    IsVisible="False" />
+            <Button Text="{x:Static resources:AppResources.DiscoverLights}" Style="{StaticResource ButtonStyle}" Clicked="OnDiscoveryButtonClicked"/>
+            
             <BoxView HeightRequest="1" HorizontalOptions="Fill" Margin="8,0" BackgroundColor="#888"/>
 
             <Label Text="{x:Static resources:AppResources.AddLight}" 

--- a/WLED/WLED/Views/DeviceAddPage.xaml.cs
+++ b/WLED/WLED/Views/DeviceAddPage.xaml.cs
@@ -56,7 +56,7 @@ namespace WLED
             if (devicesFoundCount == 0 || !address.Equals("192.168.4.1")) OnDeviceCreated(new DeviceCreatedEventArgs(device));
         }
 
-        private void OnDiscoveryButtonClicked(object sender, EventArgs e)
+        private async void OnDiscoveryButtonClicked(object sender, EventArgs e)
         {
             discoveryMode = !discoveryMode;
             Button b = sender as Button;
@@ -64,27 +64,25 @@ namespace WLED
             var discovery = DeviceDiscovery.GetInstance();
             if (discoveryMode)
             {
-                /*b.Text = AppResources.StopDiscovery;
-                devicesFoundCount = 0;
-                IReadOnlyList<IZeroconfHost> results = await ZeroconfResolver.ResolveAsync("_http._tcp.local.");
-                foreach(var resp in results)
-                {
-                    Console.WriteLine(resp.ToString());
-                }*/
-                //Start mDNS discovery
                 b.Text = AppResources.StopDiscovery;
                 devicesFoundCount = 0;
                 discovery.ValidDeviceFound += OnDeviceCreated;
                 discoveryResultLabel.IsVisible = true;
+                activityIndicator.IsVisible = true;
                 discoveryResultLabel.Text = AppResources.NoLightsFound;
-                discovery.StartDiscovery();
-            } else
+                bool isFinished = await discovery.StartDiscovery();
+                if (isFinished)
+                {
+                    activityIndicator.IsVisible = false;
+                    b.Text = AppResources.DiscoverLights;
+                    discovery.ValidDeviceFound -= OnDeviceCreated;
+                }
+            } 
+            else
             {
-                //Stop mDNS discovery
-                //discovery.StopDiscovery();
                 discovery.ValidDeviceFound -= OnDeviceCreated;
                 b.Text = AppResources.DiscoverLights;
-            }      
+            }    
         }
 
         protected virtual void OnDeviceCreated(DeviceCreatedEventArgs e)
@@ -113,7 +111,6 @@ namespace WLED
             if (discoveryMode)
             {
                 var discovery = DeviceDiscovery.GetInstance();
-                //discovery.StopDiscovery();
                 discovery.ValidDeviceFound -= OnDeviceCreated;
             }
         }
@@ -127,9 +124,6 @@ namespace WLED
         public DeviceCreatedEventArgs(WLEDDevice created, bool refresh = true)
         {
             CreatedDevice = created;
-
-            //DeviceDiscovery already made an API request to confirm that the new device is a WLED light,
-            //so a refresh is only required for manually added devices
             RefreshRequired = refresh;
         }
     }

--- a/WLED/WLED/Views/DeviceAddPage.xaml.cs
+++ b/WLED/WLED/Views/DeviceAddPage.xaml.cs
@@ -3,6 +3,8 @@ using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 using WLED.Views;
 using WLED.Resources;
+using Zeroconf;
+using System.Collections.Generic;
 
 namespace WLED
 {
@@ -62,6 +64,13 @@ namespace WLED
             var discovery = DeviceDiscovery.GetInstance();
             if (discoveryMode)
             {
+                /*b.Text = AppResources.StopDiscovery;
+                devicesFoundCount = 0;
+                IReadOnlyList<IZeroconfHost> results = await ZeroconfResolver.ResolveAsync("_http._tcp.local.");
+                foreach(var resp in results)
+                {
+                    Console.WriteLine(resp.ToString());
+                }*/
                 //Start mDNS discovery
                 b.Text = AppResources.StopDiscovery;
                 devicesFoundCount = 0;
@@ -72,7 +81,7 @@ namespace WLED
             } else
             {
                 //Stop mDNS discovery
-                discovery.StopDiscovery();
+                //discovery.StopDiscovery();
                 discovery.ValidDeviceFound -= OnDeviceCreated;
                 b.Text = AppResources.DiscoverLights;
             }      
@@ -104,7 +113,7 @@ namespace WLED
             if (discoveryMode)
             {
                 var discovery = DeviceDiscovery.GetInstance();
-                discovery.StopDiscovery();
+                //discovery.StopDiscovery();
                 discovery.ValidDeviceFound -= OnDeviceCreated;
             }
         }

--- a/WLED/WLED/WLED.csproj
+++ b/WLED/WLED/WLED.csproj
@@ -24,10 +24,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Syncfusion.Xamarin.Buttons" Version="19.2.0.49" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0-preview.6.21352.12" />
-    <PackageReference Include="Tmds.MDns" Version="0.7.1" />
     <PackageReference Include="TouchTracking.Forms" Version="1.1.0" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+    <PackageReference Include="Zeroconf" Version="3.5.11" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Migrating to a more frequently updated backend for Zeroconf.

This should fix the issues seen in iOS14.5+ where "Discover Lights" would return no results.